### PR TITLE
Automatically sets the PlayerController in UiNav Widget as the owner 

### DIFF
--- a/Source/UINavigation/Private/UINavWidget.cpp
+++ b/Source/UINavigation/Private/UINavWidget.cpp
@@ -71,6 +71,12 @@ void UUINavWidget::NativeConstruct()
 
 void UUINavWidget::InitialSetup()
 {
+	//Checks if the Player Controller is still valid
+	if (UINavPC == nullptr)
+	{
+		ConfigureUINavPC();
+	}
+
 	//If widget was already setup, apply only certain steps
 	if (bCompletedSetup)
 	{
@@ -80,10 +86,6 @@ void UUINavWidget::InitialSetup()
 
 	bSetupStarted = true;
 	WidgetClass = GetClass();
-	if (UINavPC == nullptr)
-	{
-		ConfigureUINavPC();
-	}
 
 	FetchButtonsInHierarchy();
 	ReadyForSetup();
@@ -195,10 +197,21 @@ void UUINavWidget::FetchButtonsInHierarchy()
 void UUINavWidget::ConfigureUINavPC()
 {
 	APlayerController* PC = Cast<APlayerController>(GetOwningPlayer());
-	if (PC == nullptr)
+	if (PC == nullptr && bAutomaticallyGetPlayerController == false)
 	{
 		DISPLAYERROR("Player Controller is Null!");
 		return;
+	}
+	else if (PC == nullptr && bAutomaticallyGetPlayerController == true) {
+		if (UGameplayStatics::GetPlayerController(GetWorld(), PlayerIndex) == nullptr) {
+			DISPLAYERROR("No Player found at Player Index!");
+			return;
+		}
+		else
+		{
+			SetOwningPlayer(UGameplayStatics::GetPlayerController(GetWorld(), PlayerIndex));
+			PC = Cast<APlayerController>(GetOwningPlayer());
+		}
 	}
 	UINavPC = Cast<UUINavPCComponent>(PC->GetComponentByClass(UUINavPCComponent::StaticClass()));
 	if (UINavPC == nullptr)

--- a/Source/UINavigation/Public/UINavWidget.h
+++ b/Source/UINavigation/Public/UINavWidget.h
@@ -187,6 +187,14 @@ public:
 		bool bShouldDestroyParent = true;
 
 
+	//If set to true, UINavWidget will automatically get and use the Player Controller from the Player at the Index specified below
+	UPROPERTY(EditDefaultsOnly, Category = UINavWidget)
+		bool bAutomaticallyGetPlayerController = false;
+
+	//This the Index of the Player that UiNavwidget will use
+	UPROPERTY(EditDefaultsOnly, Category = UINavWidget, meta = (EditCondition = bAutomaticallyGetPlayerController))
+		int PlayerIndex = 0;
+
 	//If set to true, buttons will be navigated by switching button states (Normal and Hovered)
 	UPROPERTY(EditDefaultsOnly, Category = UINavWidget)
 		bool bUseButtonStates = false;

--- a/UINavigation.uplugin
+++ b/UINavigation.uplugin
@@ -1,7 +1,7 @@
 {
 	"FileVersion": 3,
 	"Version": 1,
-	"VersionName": "2.16.1",
+	"VersionName": "2.16.2",
 	"FriendlyName": "UI Navigation",
 	"Description": "A plugin that allows you to easily setup mouse, keyboard and controller navigation in UMG, among other things.",
 	"Category": "Plugins",


### PR DESCRIPTION
#78
Adds functionality to automatically get and set the player controller.
Also added 2 vars to the class defaults in the UINavWidget that control this behavior.
Fixes an issue with #79 where all the indentation was changed.