### PR TITLE
Fix issue with select not working after going back to the widget

### DIFF
--- a/Source/UINavigation/Private/UINavWidget.cpp
+++ b/Source/UINavigation/Private/UINavWidget.cpp
@@ -2473,14 +2473,18 @@ void UUINavWidget::OnPreSelect(int Index, bool bMouseClick)
 
 		SwitchButtonStyle(UINavButtons[Index]->IsPressed() || SelectCount > 1 ? EButtonStyle::Pressed : (Index == ButtonIndex ? EButtonStyle::Hovered : EButtonStyle::Normal), ButtonIndex);
 
-		SelectCount--;
+		if(SelectCount > 0){
+			SelectCount--;
+		}
 		if (SelectCount == 0) SelectedButtonIndex = -1;
 	}
 	else
 	{
 		SwitchButtonStyle(UINavButtons[Index]->IsPressed() || SelectCount > 1 ? EButtonStyle::Pressed : (Index == ButtonIndex ? EButtonStyle::Hovered : EButtonStyle::Normal), ButtonIndex);
 
-		SelectCount--;
+		if(SelectCount > 0){
+			SelectCount--;
+		}
 		if (SelectCount == 0)
 		{
 			SelectedButtonIndex = -1;


### PR DESCRIPTION
With the new changes and selectcount being reset to 0 in return to parent function every time... When we try to decrement in OnPreSelect() function if selectcount is already 0... it will set it's value to 255. Added a condition for the decrement.