### PR TITLE
Fixed vr inputs showing up as gamepad inputs

### DIFF
--- a/Source/UINavigation/Private/UINavBlueprintFunctionLibrary.cpp
+++ b/Source/UINavigation/Private/UINavBlueprintFunctionLibrary.cpp
@@ -95,11 +95,11 @@ bool UUINavBlueprintFunctionLibrary::RespectsRestriction(FKey Key, EInputRestric
 		case EInputRestriction::Keyboard_Mouse:
 			return !Key.IsGamepadKey();
 			break;
-		case EInputRestriction::Gamepad:
-			return (Key.IsGamepadKey() && !IsVRKey(Key));
-			break;
 		case EInputRestriction::VR:
 			return IsVRKey(Key);
+			break;
+		case EInputRestriction::Gamepad:
+			return (Key.IsGamepadKey() && !IsVRKey(Key));
 			break;
 	}
 

--- a/Source/UINavigation/Private/UINavBlueprintFunctionLibrary.cpp
+++ b/Source/UINavigation/Private/UINavBlueprintFunctionLibrary.cpp
@@ -9,6 +9,9 @@
 #include "Kismet/GameplayStatics.h"
 #include "IXRTrackingSystem.h"
 
+FString Platform = UGameplayStatics::GetPlatformName();
+FString HMD = GEngine->XRSystem->GetSystemName().ToString();
+
 void UUINavBlueprintFunctionLibrary::SetSoundClassVolume(USoundClass * TargetClass, float NewVolume)
 {
 	if (TargetClass == nullptr) return;
@@ -83,8 +86,6 @@ void UUINavBlueprintFunctionLibrary::ResetInputSettings()
 
 bool UUINavBlueprintFunctionLibrary::RespectsRestriction(FKey Key, EInputRestriction Restriction)
 {
-	FString HMD = GEngine->XRSystem->GetSystemName().ToString();
-
 	switch (Restriction)
 	{
 		case EInputRestriction::None:
@@ -103,12 +104,11 @@ bool UUINavBlueprintFunctionLibrary::RespectsRestriction(FKey Key, EInputRestric
 			if (HMD == "OculusHMD") {
 				return IsKeyInCategory(Key, "Oculus");
 			}
-			else if (HMD == "PSVR") {
+			else if (HMD == "Morpheus") {
 				return IsKeyInCategory(Key, "PSMove");
 			}
 			break;
 		case EInputRestriction::Gamepad:
-			FString Platform = UGameplayStatics::GetPlatformName();
 			if (Platform == "Windows") {
 				return (Key.IsGamepadKey() && !IsVRKey(Key));
 			}

--- a/Source/UINavigation/Private/UINavBlueprintFunctionLibrary.cpp
+++ b/Source/UINavigation/Private/UINavBlueprintFunctionLibrary.cpp
@@ -9,9 +9,6 @@
 #include "Kismet/GameplayStatics.h"
 #include "IXRTrackingSystem.h"
 
-FString Platform = UGameplayStatics::GetPlatformName();
-FString HMD = GEngine->XRSystem->GetSystemName().ToString();
-
 void UUINavBlueprintFunctionLibrary::SetSoundClassVolume(USoundClass * TargetClass, float NewVolume)
 {
 	if (TargetClass == nullptr) return;
@@ -86,36 +83,32 @@ void UUINavBlueprintFunctionLibrary::ResetInputSettings()
 
 bool UUINavBlueprintFunctionLibrary::RespectsRestriction(FKey Key, EInputRestriction Restriction)
 {
+	FString HMD = GEngine->XRSystem->GetSystemName().ToString();
 	switch (Restriction)
 	{
-		case EInputRestriction::None:
-			return true;
-			break;
-		case EInputRestriction::Keyboard:
-			return (!Key.IsMouseButton() && !Key.IsGamepadKey());
-			break;
-		case EInputRestriction::Mouse:
-			return Key.IsMouseButton();
-			break;
-		case EInputRestriction::Keyboard_Mouse:
-			return !Key.IsGamepadKey();
-			break;
-		case EInputRestriction::VR:
-			if (HMD == "OculusHMD") {
-				return IsKeyInCategory(Key, "Oculus");
-			}
-			else if (HMD == "Morpheus") {
-				return IsKeyInCategory(Key, "PSMove");
-			}
-			break;
-		case EInputRestriction::Gamepad:
-			if (Platform == "Windows") {
-				return (Key.IsGamepadKey() && !IsVRKey(Key));
-			}
-			else {
-				return ((Key.IsGamepadKey() || Key.GetMenuCategory().ToString() == Platform) && !IsVRKey(Key));
-			}
-			break;
+	case EInputRestriction::None:
+		return true;
+		break;
+	case EInputRestriction::Keyboard:
+		return (!Key.IsMouseButton() && !Key.IsGamepadKey());
+		break;
+	case EInputRestriction::Mouse:
+		return Key.IsMouseButton();
+		break;
+	case EInputRestriction::Keyboard_Mouse:
+		return !Key.IsGamepadKey();
+		break;
+	case EInputRestriction::VR:
+		if (HMD == "OculusHMD") {
+			return IsKeyInCategory(Key, "Oculus");
+		}
+		else if (HMD == "Morpheus") {
+			return IsKeyInCategory(Key, "PSMove");
+		}
+		break;
+	case EInputRestriction::Gamepad:
+		return (Key.IsGamepadKey() && !IsVRKey(Key));
+		break;
 	}
 
 	return false;

--- a/Source/UINavigation/Private/UINavBlueprintFunctionLibrary.cpp
+++ b/Source/UINavigation/Private/UINavBlueprintFunctionLibrary.cpp
@@ -96,7 +96,7 @@ bool UUINavBlueprintFunctionLibrary::RespectsRestriction(FKey Key, EInputRestric
 			return !Key.IsGamepadKey();
 			break;
 		case EInputRestriction::Gamepad:
-			return Key.IsGamepadKey();
+			return (Key.IsGamepadKey() && Key.GetMenuCategory() == "Gamepad");
 			break;
 	}
 

--- a/Source/UINavigation/Private/UINavBlueprintFunctionLibrary.cpp
+++ b/Source/UINavigation/Private/UINavBlueprintFunctionLibrary.cpp
@@ -96,7 +96,7 @@ bool UUINavBlueprintFunctionLibrary::RespectsRestriction(FKey Key, EInputRestric
 			return !Key.IsGamepadKey();
 			break;
 		case EInputRestriction::Gamepad:
-			return (Key.IsGamepadKey() && Key.GetMenuCategory() == "Gamepad");
+			return (Key.IsGamepadKey() && !IsVRKey(Key));
 			break;
 	}
 
@@ -149,4 +149,10 @@ UUINavButton* UUINavBlueprintFunctionLibrary::Conv_UINavComponentToUINavButton(U
 int UUINavBlueprintFunctionLibrary::Conv_GridToInt(FGrid Grid)
 {
 	return Grid.GridIndex;
+}
+
+bool UUINavBlueprintFunctionLibrary::IsVRKey(FKey Key)
+{
+	return Key.ToString().Contains("Oculus") || Key.ToString().Contains("Vive") ||
+		Key.ToString().Contains("MixedReality") || Key.ToString().Contains("Valve");
 }

--- a/Source/UINavigation/Private/UINavBlueprintFunctionLibrary.cpp
+++ b/Source/UINavigation/Private/UINavBlueprintFunctionLibrary.cpp
@@ -98,6 +98,9 @@ bool UUINavBlueprintFunctionLibrary::RespectsRestriction(FKey Key, EInputRestric
 		case EInputRestriction::Gamepad:
 			return (Key.IsGamepadKey() && !IsVRKey(Key));
 			break;
+		case EInputRestriction::VR:
+			return IsVRKey(Key);
+			break;
 	}
 
 	return false;

--- a/Source/UINavigation/Public/Data/InputRestriction.h
+++ b/Source/UINavigation/Public/Data/InputRestriction.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Gonçalo Marques - All Rights Reserved
+// Copyright (C) 2019 Gonï¿½alo Marques - All Rights Reserved
 
 #pragma once
 #include "InputRestriction.generated.h"
@@ -11,4 +11,5 @@ enum class EInputRestriction : uint8
 	Mouse UMETA(DisplayName = "Mouse"),
 	Keyboard_Mouse UMETA(DisplayName = "Keyboard and Mouse"),
 	Gamepad UMETA(DisplayName = "Gamepad"),
+	VR UMETA(DisplayName = "VR")
 };

--- a/Source/UINavigation/Public/UINavBlueprintFunctionLibrary.h
+++ b/Source/UINavigation/Public/UINavBlueprintFunctionLibrary.h
@@ -61,5 +61,8 @@ public:
 
 	UFUNCTION(BlueprintPure, Category = UINavigationLibrary)
 		static bool IsVRKey(FKey Key);
+
+	UFUNCTION(BlueprintPure, Category = UINavigationLibrary)
+		static bool IsKeyInCategory(FKey Key, FString Category);
 	
 };

--- a/Source/UINavigation/Public/UINavBlueprintFunctionLibrary.h
+++ b/Source/UINavigation/Public/UINavBlueprintFunctionLibrary.h
@@ -58,5 +58,8 @@ public:
 
 	UFUNCTION(BlueprintPure, meta = (DisplayName = "Grid To Index", CompactNodeTitle = "->", BlueprintAutocast), Category = "Navigation Grid")
 		static int Conv_GridToInt(FGrid Grid);
+
+	UFUNCTION(BlueprintPure, Category = UINavigationLibrary)
+		static bool IsVRKey(FKey Key);
 	
 };


### PR DESCRIPTION
Fixed an issue where vr inputs were showing up as gamepad inputs.

Before:

![image](https://user-images.githubusercontent.com/50789023/110894106-e1483380-82bc-11eb-9b06-5399018830e7.png)

After:

![image](https://user-images.githubusercontent.com/50789023/110894134-ee652280-82bc-11eb-992f-63c7ea70a6f8.png)
