### PR TITLE
Update selector position on next tick (frame)

### DIFF
--- a/Source/UINavigation/Private/UINavWidget.cpp
+++ b/Source/UINavigation/Private/UINavWidget.cpp
@@ -717,9 +717,24 @@ void UUINavWidget::NativeTick(const FGeometry & MyGeometry, float DeltaTime)
 {
 	Super::NativeTick(MyGeometry, DeltaTime);
 
-	if (IsSelectorValid() && bMovingSelector)
+	if ( IsSelectorValid() )
 	{
-		HandleSelectorMovement(DeltaTime);
+		if ( bUpdateSelector )
+		{
+			if ( UpdateSelectorWaitForTick == 1)
+			{
+				if (MoveCurve != nullptr) BeginSelectorMovement( UpdateSelectorPrevButtonIndex, UpdateSelectorNextButtonIndex );
+				else UpdateSelectorLocation( UpdateSelectorNextButtonIndex );
+				bUpdateSelector = false;
+			}
+			
+			UpdateSelectorWaitForTick++;
+		}
+
+		if ( bMovingSelector )
+		{
+			HandleSelectorMovement(DeltaTime);
+		}
 	}
 }
 
@@ -1245,21 +1260,21 @@ void UUINavWidget::ReplaceButtonInNavigationGrid(UUINavButton * ButtonToReplace,
 
 void UUINavWidget::UpdateCurrentButton(UUINavButton * NewCurrentButton)
 {
-	ButtonIndex = NewCurrentButton->ButtonIndex;
-	if (IsSelectorValid())
-	{
-		if (MoveCurve != nullptr) BeginSelectorMovement(NewCurrentButton->ButtonIndex);
-		else UpdateSelectorLocation(NewCurrentButton->ButtonIndex);
-	}
 
 	for (UScrollBox* ScrollBox : ScrollBoxes)
 	{
-		if (NewCurrentButton->IsChildOf(ScrollBox))
-		{
-			ScrollBox->ScrollWidgetIntoView(NewCurrentButton, bAnimateScrollBoxes);
-			break;
-		}
+		ScrollBox->ScrollWidgetIntoView(NewCurrentButton, bAnimateScrollBoxes);
 	}
+
+	ButtonIndex = NewCurrentButton->ButtonIndex;
+	if (IsSelectorValid())
+	{
+		UpdateSelectorWaitForTick = 0;
+		UpdateSelectorPrevButtonIndex = ButtonIndex;
+		UpdateSelectorNextButtonIndex = NewCurrentButton->ButtonIndex;
+		bUpdateSelector = true;
+	}
+
 }
 
 void UUINavWidget::ClearGrid(const int GridIndex, const bool bAutoNavigate)
@@ -2392,8 +2407,10 @@ void UUINavWidget::DispatchNavigation(const int Index)
 
 	if (Index > -1 && IsSelectorValid())
 	{
-		if (MoveCurve != nullptr) BeginSelectorMovement(Index);
-		else UpdateSelectorLocation(Index);
+		UpdateSelectorWaitForTick = 0;
+		UpdateSelectorPrevButtonIndex = ButtonIndex;
+		UpdateSelectorNextButtonIndex = Index;
+		bUpdateSelector = true;
 	}
 
 	if (bUseTextColor) UpdateTextColor(Index);
@@ -2406,12 +2423,12 @@ void UUINavWidget::DispatchNavigation(const int Index)
 	if (UINavAnimations.Num() > 0) ExecuteAnimations(ButtonIndex, Index);
 }
 
-void UUINavWidget::BeginSelectorMovement(const int Index)
+void UUINavWidget::BeginSelectorMovement(const int PrevButtonIndex, const int NextButtonIndex)
 {
 	if (MoveCurve == nullptr) return;
 
-	SelectorOrigin = bMovingSelector ? TheSelector->RenderTransform.Translation : GetButtonLocation(ButtonIndex);
-	SelectorDestination = GetButtonLocation(Index);
+	SelectorOrigin = bMovingSelector ? TheSelector->RenderTransform.Translation : GetButtonLocation(PrevButtonIndex);
+	SelectorDestination = GetButtonLocation(NextButtonIndex);
 	Distance = SelectorDestination - SelectorOrigin;
 
 	float MinTime, MaxTime;

--- a/Source/UINavigation/Public/UINavWidget.h
+++ b/Source/UINavigation/Public/UINavWidget.h
@@ -34,6 +34,12 @@ protected:
 	bool bMovingSelector = false;
 	bool bIgnoreMouseEvent = false;
 	bool bReturning = false;
+	
+	bool bUpdateSelector = false;
+	int UpdateSelectorPrevButtonIndex;
+	int UpdateSelectorNextButtonIndex;
+	int UpdateSelectorWaitForTick;
+
 	bool bReturningToParent = false;
 
 	bool bAutoAppended = false;
@@ -123,7 +129,7 @@ protected:
 	*/
 	FVector2D GetButtonLocation(const int Index);
 
-	void BeginSelectorMovement(const int Index);
+	void BeginSelectorMovement(const int PrevButtonIndex, const int NextButtonIndex);
 	void HandleSelectorMovement(const float DeltaTime);
 
 public:


### PR DESCRIPTION
Fixes selector position when autoscrolling and other potential selector errors caused by an unreal UI function that does not guarantee elements to be updated on current frame.

In the places where the selector update functions where called I set some variables, including a boolean and a frame count variable. then in the NativeTick function I call the selector update function when the boolean is true and the frame count is one, so update happens in next tick. I also needed some variables to keep previous and next button between frames.

Regarding "if (NewCurrentButton->IsChildOf(ScrollBox))" I think I removed it because reading the unreal source code I saw the same check is performed again inside "ScrollWidgetIntoView( )" stack call at some point. It is related with a warning message that supposedly makes no harm.

Please consider this fix. I leave it here just in case someone needs it. We can also discuss other approaches.