### PR TITLE
Selector one-frame delay in 5.0

### DIFF
--- a/Source/UINavigation/Public/UINavWidget.h
+++ b/Source/UINavigation/Public/UINavWidget.h
@@ -34,6 +34,12 @@ protected:
 	bool bMovingSelector = false;
 	bool bIgnoreMouseEvent = false;
 	bool bReturning = false;
+	
+	bool bUpdateSelector = false;
+	int UpdateSelectorPrevButtonIndex;
+	int UpdateSelectorNextButtonIndex;
+	int UpdateSelectorWaitForTick;
+
 	bool bReturningToParent = false;
 
 	bool bAutoAppended = false;
@@ -123,7 +129,7 @@ protected:
 	*/
 	FVector2D GetButtonLocation(const int Index);
 
-	void BeginSelectorMovement(const int Index);
+	void BeginSelectorMovement(const int PrevButtonIndex, const int NextButtonIndex);
 	void HandleSelectorMovement(const float DeltaTime);
 
 public:

--- a/Source/UINavigation/Public/UINavWidget.h
+++ b/Source/UINavigation/Public/UINavWidget.h
@@ -35,10 +35,13 @@ protected:
 	bool bIgnoreMouseEvent = false;
 	bool bReturning = false;
 	
-	bool bUpdateSelector = false;
+	bool bShouldTickUINavSetup = false;
+	int UINavSetupWaitForTick=0;
+
+	bool bShouldTickUpdateSelector = false;
 	int UpdateSelectorPrevButtonIndex;
 	int UpdateSelectorNextButtonIndex;
-	int UpdateSelectorWaitForTick;
+	int UpdateSelectorWaitForTick=0;
 
 	bool bReturningToParent = false;
 
@@ -67,8 +70,6 @@ protected:
 	FVector2D SelectorOrigin;
 	FVector2D SelectorDestination;
 	FVector2D Distance;
-
-	FTimerHandle SelectorHandle;
 
 	TArray<FDynamicEdgeNavigation> DynamicEdgeNavigations;
 
@@ -403,7 +404,6 @@ public:
 	/**
 	*	Called manually to setup all the elements in the Widget
 	*/
-	UFUNCTION()
 	virtual void UINavSetup();
 
 	void AddParentToPath(const int IndexInParent);


### PR DESCRIPTION
Fixes selector position when autoscrolling and other potential selector errors caused by an unreal UI function that does not guarantee elements to be updated on current frame.

In the places where the selector update functions where called I set some variables, including a boolean and a frame count variable. then in the NativeTick function I call the selector update function when the boolean is true and the frame count is one, so update happens in next tick. I also needed some variables to keep previous and next button between frames.

Regarding "if (NewCurrentButton->IsChildOf(ScrollBox))" I removed it because reading the unreal source code I saw the same check is performed again inside "ScrollWidgetIntoView( )" stack call at some point. It is related with a warning message that supposedly makes no harm.

Please consider this fix. I leave it here just in case someone needs it. We can also discuss other approaches.