### PR TITLE
Update selector position on next tick (frame) with timers

### DIFF
--- a/Source/UINavigation/Public/UINavWidget.h
+++ b/Source/UINavigation/Public/UINavWidget.h
@@ -123,7 +123,6 @@ protected:
 	*/
 	FVector2D GetButtonLocation(const int Index);
 
-	void BeginSelectorMovement(const int Index);
 	void HandleSelectorMovement(const float DeltaTime);
 
 public:
@@ -468,6 +467,14 @@ public:
 	*/
 	UFUNCTION(BlueprintCallable, Category = UINavWidget)
 		void UpdateSelectorLocation(const int Index);
+
+	/**
+	*	Changes the selector's location to that of the button with the given index in the Button's array. Performs a transition animation following the animation curve.
+	*
+	*	@param	Index  The new button's index in the Button's array
+	*/
+	UFUNCTION(BlueprintCallable, Category = UINavWidget)
+		void BeginSelectorMovement(const int PrevButtonIndex, const int NextButtonIndex);
 
 	/**
 	*	Changes the color of the text with the specified index to the specified color


### PR DESCRIPTION
This is similar to #134 but using timers/timer delegates to delay function executions until next frame. Code is more clear. I have tested it on 5.0 and works. I supose it will work on 4.26 also.

there is still code at the end of DispatchNavigation which i am not sure if should be delayed also  (like the ExecuteAnimations(ButtonIndex, Index) ) function.