### PR TITLE
Updating enhanced input bindings to use ETriggerEvent::Completed

### DIFF
--- a/Source/UINavigation/Private/UINavPCComponent.cpp
+++ b/Source/UINavigation/Private/UINavPCComponent.cpp
@@ -263,12 +263,12 @@ void UUINavPCComponent::BindMenuEnhancedInputs()
 		EnhancedInputComponent->BindAction(InputActions->IA_MenuNext, ETriggerEvent::Started, this, &UUINavPCComponent::MenuNext);
 		EnhancedInputComponent->BindAction(InputActions->IA_MenuPrevious, ETriggerEvent::Started, this, &UUINavPCComponent::MenuPrevious);
 
-		EnhancedInputComponent->BindAction(InputActions->IA_MenuUp, ETriggerEvent::Canceled, this, &UUINavPCComponent::MenuUpRelease);
-		EnhancedInputComponent->BindAction(InputActions->IA_MenuDown, ETriggerEvent::Canceled, this, &UUINavPCComponent::MenuDownRelease);
-		EnhancedInputComponent->BindAction(InputActions->IA_MenuLeft, ETriggerEvent::Canceled, this, &UUINavPCComponent::MenuLeftRelease);
-		EnhancedInputComponent->BindAction(InputActions->IA_MenuRight, ETriggerEvent::Canceled, this, &UUINavPCComponent::MenuRightRelease);
-		EnhancedInputComponent->BindAction(InputActions->IA_MenuSelect, ETriggerEvent::Canceled, this, &UUINavPCComponent::MenuSelectRelease);
-		EnhancedInputComponent->BindAction(InputActions->IA_MenuReturn, ETriggerEvent::Canceled, this, &UUINavPCComponent::MenuReturnRelease);
+		EnhancedInputComponent->BindAction(InputActions->IA_MenuUp, ETriggerEvent::Completed, this, &UUINavPCComponent::MenuUpRelease);
+		EnhancedInputComponent->BindAction(InputActions->IA_MenuDown, ETriggerEvent::Completed, this, &UUINavPCComponent::MenuDownRelease);
+		EnhancedInputComponent->BindAction(InputActions->IA_MenuLeft, ETriggerEvent::Completed, this, &UUINavPCComponent::MenuLeftRelease);
+		EnhancedInputComponent->BindAction(InputActions->IA_MenuRight, ETriggerEvent::Completed, this, &UUINavPCComponent::MenuRightRelease);
+		EnhancedInputComponent->BindAction(InputActions->IA_MenuSelect, ETriggerEvent::Completed, this, &UUINavPCComponent::MenuSelectRelease);
+		EnhancedInputComponent->BindAction(InputActions->IA_MenuReturn, ETriggerEvent::Completed, this, &UUINavPCComponent::MenuReturnRelease);
 		
 		if (CustomEnhancedInputs.Num() > 0)
 		{


### PR DESCRIPTION
I came across an issue where UINavComponents in a grid would constantly cycle after pressing an directional key (WSAD or D-Pad). 

After some digging, I noticed that the Enhanced Input bindings are currently bound to `ETriggerEvent::Canceled`. Based on the description of the trigger events, I don't believe this is correct: https://github.com/EpicGames/UnrealEngine/blob/99b6e203a15d04fc7bbbf554c421a985c1ccb8f1/Engine/Plugins/Experimental/EnhancedInput/Source/EnhancedInput/Private/EnhancedPlayerInput.cpp#L11-L20.

Updating these bindings to use `ETriggerEvent::Completed` instead resolved this issue for me. During my testing, I was unable to uncover any adverse side effects.