### PR TITLE
Fixed GetButtonAtGridIndex not working for -1 IndexInGrid (-1 refers to last button on grid)

### DIFF
--- a/Source/UINavigation/Private/UINavWidget.cpp
+++ b/Source/UINavigation/Private/UINavWidget.cpp
@@ -3148,11 +3148,13 @@ int UUINavWidget::GetGridStartingIndex(const int GridIndex)
 
 UUINavButton * UUINavWidget::GetButtonAtGridIndex(const int GridIndex, int IndexInGrid)
 {
-	if (!NavigationGrids.IsValidIndex(GridIndex) || IndexInGrid < 0) return nullptr;
+	if (!NavigationGrids.IsValidIndex(GridIndex) || IndexInGrid < -1) return nullptr;
 
 	const FGrid& ButtonGrid = NavigationGrids[GridIndex];
 	if (ButtonGrid.FirstButton == nullptr) return nullptr;
-	if (IndexInGrid == -1) IndexInGrid = ButtonGrid.GetDimension() - 1;
+	const int ButtonGridDimension = ButtonGrid.GetDimension();
+	if (IndexInGrid >= ButtonGridDimension) return nullptr;
+	if (IndexInGrid == -1) IndexInGrid = ButtonGridDimension - 1;
 	const int NewIndex = ButtonGrid.FirstButton->ButtonIndex + IndexInGrid;
 
 	if (NewIndex >= UINavButtons.Num()) return nullptr;


### PR DESCRIPTION
Setting get button at grid index to -1 to jump to the last button of a grid has stopped working
You can check it on UINav simple pack without changing anything, pressing the menu up key in options menu does not go to the last element of the list, it remains in place.

This fixes the issue.

![imagen](https://user-images.githubusercontent.com/2369012/182738985-2addba63-6a2f-45c5-8984-dd12d7704790.png)
