### PR TITLE
Fix for enhanced input being interpreted always as axisType when rebinding keys

### DIFF
--- a/Source/UINavigation/Private/UINavInputBox.cpp
+++ b/Source/UINavigation/Private/UINavInputBox.cpp
@@ -119,8 +119,6 @@ void UUINavInputBox::CreateInputKeyWidgets()
 	TArray<FInputActionKeyMapping> Actions;
 	TArray<FInputAxisKeyMapping> Axes;
 
-	ProcessInputName();
-
 	if (IS_AXIS) Settings->GetAxisMappingByName(InputName, Axes);
 	else Settings->GetActionMappingByName(InputName, Actions);
 
@@ -490,7 +488,10 @@ void UUINavInputBox::ProcessInputName()
 {
 	if (IS_ENHANCED_INPUT)
 	{
-		AxisType = InputActionData.bPositive ? EAxisType::Positive : EAxisType::Negative;
+		if (InputActionData.Action->ValueType != EInputActionValueType::Boolean)
+		{
+			AxisType = InputActionData.bPositive ? EAxisType::Positive : EAxisType::Negative;
+		}
 		InputName = InputActionData.Action->GetFName();
 		if (InputActionData.DisplayName.IsEmpty())
 		{

--- a/Source/UINavigation/Private/UINavWidget.cpp
+++ b/Source/UINavigation/Private/UINavWidget.cpp
@@ -837,7 +837,7 @@ FReply UUINavWidget::NativeOnKeyUp(const FGeometry & InGeometry, const FKeyEvent
 {
 	if (UINavPC->GetInputMode() != EInputMode::UI)
 	{
-		if (ReceiveInputType != EReceiveInputType::None)
+		if (IsRebindingInput())
 		{
 			FKey Key = InKeyEvent.GetKey();
 


### PR DESCRIPTION
Hi @goncasmage1 I found an issue with code around ProcessKeybind() calls when using enhanced input, it seems that in UINavInputBox.cpp line 494 AxisType is always set to be of axis type in this line:

    AxisType = InputActionData.bPositive ? EAxisType::Positive : EAxisType::Negative; 

This has several consequences:
 1- in UINavWidget.cpp in function NativeOnKeyUp() and in UINavPCComponent HandleKeyUpEvent() this code always triggers:

if (ActiveWidget->ReceiveInputType == EReceiveInputType::Axis)
            {
                Key = ActiveWidget->UINavInputContainer->GetAxisFromKey(Key);
            }

But GetAxisFromKey returns the key if it is not mapped to an axis (GetAxisFromKey seems to be a check that does not take into account enhanced input) so non axis keys are still rebinded. 

2- When handling mouse key events in UINavWidget.cpp, the code in functions PressEvent and NativeOnMouseButtonDown always trigger the following code:

if (ReceiveInputType == EReceiveInputType::Axis) CancelRebind()

So rebind for mouse key inputs is always cancelled And I can not rebind mouse keys using enhanced input.

I made a change in UINavInputBox ProcessInputName function to read from InputActionData.Action->ValueType if it is an axis:

https://docs.unrealengine.com/4.26/en-US/API/Plugins/EnhancedInput/UInputAction/
https://docs.unrealengine.com/4.26/en-US/API/Plugins/EnhancedInput/EInputActionValueType/

This fixes the issues described, please consider these changes among other things you think would be needed for the code to work better with enhanced input IC or if you are going to implement this in a different way.

Also ProcessInputName is calle twice in UINavInputbox.cpp, in line 36 and another time in line 122 for non enhanced input, please check that. 

The other change is an if condition equivalent to the function used in similar places along UINavWidget.