### PR TITLE
Prevent Menu Deletion

### DIFF
--- a/Source/UINavigation/Private/UINavWidget.cpp
+++ b/Source/UINavigation/Private/UINavWidget.cpp
@@ -2750,7 +2750,7 @@ void UUINavWidget::ReturnToParent(const bool bRemoveAllParents, const int ZOrder
 			{
 				WidgetComp->SetWidget(nullptr);
 			}
-			else
+			else if (bCanBeRemovedFromParent)
 			{
 				bReturningToParent = true;
 				RemoveFromParent();

--- a/Source/UINavigation/Public/UINavWidget.h
+++ b/Source/UINavigation/Public/UINavWidget.h
@@ -286,8 +286,9 @@ public:
 	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "UINavigation Text", meta = (EditCondition = "bUseTextColor"))
 	FLinearColor TextNavigatedColor = FColor::Green;
 
-
-
+	//Prevent the widget to be deleted, useful if you want the main menu to be handle differently than the other menus
+	UPROPERTY(EditDefaultsOnly, Category = UINavWidget)
+	bool bCanBeRemovedFromParent = true;
 	/*********************************************************************************/
 
 	


### PR DESCRIPTION
Prevent the widget from being deleted, useful if you want the main menu to be handle differently than the other menus