### PR TITLE
Handle button Cancel (useful for gamepad)

### DIFF
--- a/Source/UINavigation/Private/UINavPCComponent.cpp
+++ b/Source/UINavigation/Private/UINavPCComponent.cpp
@@ -184,6 +184,12 @@ void UUINavPCComponent::BindMenuInputs()
 		FInputActionBinding& Action6_2 = InputComponent->BindAction("MenuReturn", IE_Released, this, &UUINavPCComponent::MenuReturnRelease);
 		Action6_2.bExecuteWhenPaused = true;
 		Action6_2.bConsumeInput = false;
+		FInputActionBinding& Action6_3 = InputComponent->BindAction("MenuCancel", IE_Pressed, this, &UUINavPCComponent::MenuCancel);
+		Action6_3.bExecuteWhenPaused = true;
+		Action6_3.bConsumeInput = false;
+		FInputActionBinding& Action6_4 = InputComponent->BindAction("MenuCancel", IE_Released, this, &UUINavPCComponent::MenuCancelRelease);
+		Action6_4.bExecuteWhenPaused = true;
+		Action6_4.bConsumeInput = false;
 
 		if (CustomInputs.Num() > 0)
 		{
@@ -1196,6 +1202,11 @@ void UUINavPCComponent::ExecuteActionByName(const FString Action, const bool bPr
 		if (bPressed) MenuReturn();
 		else MenuReturnRelease();
 	}
+	else if (Action.Contains("MenuCancel"))
+	{
+		if (bPressed) MenuCancel();
+		else MenuCancelRelease();
+	}
 	else if (Action.Contains("MenuNext") && bPressed)
 	{
 		MenuNext();
@@ -1280,6 +1291,24 @@ void UUINavPCComponent::MenuReturnRelease()
 
 	ClearTimer();
 	ActiveWidget->MenuReturnRelease();
+}
+
+void UUINavPCComponent::MenuCancel()
+{
+	if (ActiveWidget == nullptr || !bAllowReturnInput) return;
+
+	ClearTimer();
+	ActiveWidget->MenuCancelPress();
+}
+
+void UUINavPCComponent::MenuCancelRelease()
+{
+	IUINavPCReceiver::Execute_OnReturn(GetOwner());
+
+	if (ActiveWidget == nullptr || !bAllowReturnInput) return;
+
+	ClearTimer();
+	ActiveWidget->MenuCancelRelease();
 }
 
 void UUINavPCComponent::MenuNext()

--- a/Source/UINavigation/Private/UINavWidget.cpp
+++ b/Source/UINavigation/Private/UINavWidget.cpp
@@ -3580,6 +3580,32 @@ void UUINavWidget::MenuReturnRelease()
 	}
 
 	bReturning = false;
+	CollectionOnReturn();
+	OnReturn();
+}
+
+void UUINavWidget::MenuCancelPress()
+{
+	bCanceling = true;
+}
+
+void UUINavWidget::MenuCancelRelease()
+{
+	if (!bCanceling) return;
+
+	if (IsRebindingInput())
+	{
+		CancelRebind();
+		return;
+	}
+
+	if (bMovingSelector)
+	{
+		HaltedIndex = RETURN_INDEX;
+		return;
+	}
+	
+	bCanceling = false;
 
 	CollectionOnReturn();
 	OnReturn();

--- a/Source/UINavigation/Public/UINavPCComponent.h
+++ b/Source/UINavigation/Public/UINavPCComponent.h
@@ -469,6 +469,7 @@ public:
 	void MenuInput(const ENavigationDirection Direction);
 	void MenuSelect();
 	void MenuReturn();
+	void MenuCancel();
 	void MenuNext();
 	void MenuPrevious();
 
@@ -478,6 +479,7 @@ public:
 	void MenuRightRelease();
 	void MenuSelectRelease();
 	void MenuReturnRelease();
+	void MenuCancelRelease();
 
 	void MouseKeyPressed(const FKey MouseKey);
 

--- a/Source/UINavigation/Public/UINavWidget.h
+++ b/Source/UINavigation/Public/UINavWidget.h
@@ -35,6 +35,7 @@ protected:
 	bool bMovingSelector = false;
 	bool bIgnoreMouseEvent = false;
 	bool bReturning = false;
+	bool bCanceling = false;
 		
 	bool bShouldTickUINavSetup = false;
 	int UINavSetupWaitForTick=0;
@@ -993,6 +994,8 @@ public:
 
 	virtual void MenuSelectPress();
 	virtual void MenuSelectRelease();
+	virtual void MenuCancelPress();
+	virtual void MenuCancelRelease();
 	virtual void MenuReturnPress();
 	virtual void MenuReturnRelease();
 


### PR DESCRIPTION
Add an extra button to handle the "Cancel" Button

Behave mostly the same as the Return but will not toggle the pause menu, just close it 
(logical with a gamepad behavior is binded on B)
![image](https://user-images.githubusercontent.com/34646501/199291148-49be18cc-da62-4024-970a-ffb002eb9db3.png)
