### PR TITLE
Finally? fixing error when removing UINavWidgets on EndPlay

### DIFF
--- a/Source/UINavigation/Private/UINavPCComponent.cpp
+++ b/Source/UINavigation/Private/UINavPCComponent.cpp
@@ -260,7 +260,9 @@ void UUINavPCComponent::SetActiveWidget(UUINavWidget * NewActiveWidget)
 		if (NewActiveWidget == nullptr)
 		{
 			IUINavPCReceiver::Execute_OnRootWidgetRemoved(GetOwner());
-			if (IsValid(PC) && IsValid(PC->Player))
+			// GetOwningPlayer will not be valid if SetActiveWidget is called during PlayerController EndPlay()
+			APlayerController *ActiveWidgetPC = ActiveWidget->GetOwningPlayer();
+			if (IsValid(ActiveWidgetPC) && IsValid(ActiveWidgetPC->Player))
 			{
 				FSlateApplication::Get().SetAllUserFocusToGameViewport();
 			}


### PR DESCRIPTION
Getting the player controller from the widget GetOwningPlayer() seems to solve the issue.

GetOwningPlayer() is performing other checks on PlayerState etc that we were missing.

Still not totally sure on how exactly UWidget::SetUserFocus(APlayerController* PlayerController) gets the PlayerController reference though.

Checked with UE_LOGS, triggers normally during execution, on EndPlay it does not trigger anymore. Error message no longer appears:

"The PlayerController is not a valid local player so it can't focus the widget."