### PR TITLE
Fix UUINavInputDisplay::UpdateInputVisuals to show image icon when an IMC is added to EnhancedInputLocalPlayerSubsystem again

### DIFF
--- a/Source/UINavigation/Private/UINavInputDisplay.cpp
+++ b/Source/UINavigation/Private/UINavInputDisplay.cpp
@@ -89,11 +89,14 @@ void UUINavInputDisplay::UpdateInputVisuals()
 		}
 
 		InputText->SetVisibility(ESlateVisibility::Collapsed);
+		InputImage->SetVisibility(ESlateVisibility::Visible);
 	}
 	else
 	{
 		InputText->SetText(UINavPC->GetEnhancedInputText(InputAction, Axis, Scale));
+
 		InputImage->SetVisibility(ESlateVisibility::Collapsed);
+		InputText->SetVisibility(ESlateVisibility::Visible);
 	}
 }
 


### PR DESCRIPTION
If the function UUINavInputDisplay::UpdateInputVisuals() is called when the IMC  has not been added or has been removed from to the EnhancedInputLocalPlayerSubsystem then the code sets the visibility of the InputImage to Collapsed.

If the IMC is added later even if the UUINavInputDisplay::UpdateInputVisuals() is called it has no code to make the image Visible again.

The opposite happens with the TextInput.

I am making this pull request so you can check the fix.