### PR TITLE
Fix update input visuals to show gamepad/keyboard text, was always showing keyboard text

### DIFF
--- a/Source/UINavigation/Private/UINavInputDisplay.cpp
+++ b/Source/UINavigation/Private/UINavInputDisplay.cpp
@@ -93,7 +93,7 @@ void UUINavInputDisplay::UpdateInputVisuals()
 	}
 	else
 	{
-		InputText->SetText(UINavPC->GetEnhancedInputText(InputAction, Axis, Scale));
+		InputText->SetText(UINavPC->GetEnhancedInputText(InputAction, Axis, Scale, UINavPC->IsUsingGamepad() ? EInputRestriction::Gamepad : EInputRestriction::Keyboard_Mouse));
 
 		InputImage->SetVisibility(ESlateVisibility::Collapsed);
 		InputText->SetVisibility(ESlateVisibility::Visible);


### PR DESCRIPTION
You can check this behavior in current UINavSimplePack project with last version. Icons are not found, so it defaults to text, but shows keyboard bindings as text only.

This fixes that. Please verify that it is correct.