### PR TITLE
SwapKeysWidget prompt consuming UUINavComponent::NativeOnKeyUp from UUINavInputBox components

### DIFF
--- a/Source/UINavigation/Private/UINavComponent.cpp
+++ b/Source/UINavigation/Private/UINavComponent.cpp
@@ -146,6 +146,7 @@ FReply UUINavComponent::NativeOnKeyUp(const FGeometry& InGeometry, const FKeyEve
 	if (bIgnoreDueToRebind || ParentWidget->UINavPC->IsListeningToInputRebind())
 	{
 		bIgnoreDueToRebind = false;
+		ParentWidget->UINavPC->ProcessRebind( InKeyEvent );
 		return Reply;
 	}
 

--- a/Source/UINavigation/Private/UINavPCComponent.cpp
+++ b/Source/UINavigation/Private/UINavPCComponent.cpp
@@ -633,18 +633,9 @@ void UUINavPCComponent::HandleKeyUpEvent(FSlateApplication& SlateApp, const FKey
 	const bool bIsGamepadKey = InKeyEvent.GetKey().IsGamepadKey();
 	const bool bShouldUnforceNavigation = !bUsingThumbstickAsMouse || !bIsSelectKey || !bIsGamepadKey;
 
-	if (IsValid(ListeningInputBox))
-	{
-		FKey Key = InKeyEvent.GetKey();
+	if (IsValid(ListeningInputBox)) return;
 
-		if (ListeningInputBox->IsAxis())
-		{
-			Key = GetAxisFromKey(Key);
-		}
-
-		ProcessRebind(InKeyEvent);
-	}
-	else if (!bShouldUnforceNavigation)
+	if (!bShouldUnforceNavigation)
 	{
 		bIgnoreMouseRelease = true;
 		SimulateMouseRelease();


### PR DESCRIPTION
[Video with the bug on discord](https://discord.com/channels/552279099800813603/1184650668980572240/1194465246975369316)

It seems that the UUINavComponent  bIgnoreDueToRebind boolean is not properly reset to false when the prompt opens or closes. And for some reason after that UUINavComponent::NativeOnNavigation enters an infinite loop.

So UUINavComponent::NativeOnKeyDown of the input box UUINavComponent sets bIgnoreDueToRebind=true on the input box component, but then swapkeysprompt is opened and its cancel button becomes selected, so the UUINavComponent::NativeOnKeyUp is being called on the swapkeys prompt  cancel button, not in the input box component. In the cancel button of the swapkeysprompt: bIgnoreDueToRebind is already false and the function ParentWidget->UINavPC->IsListeningToInputRebind() is already returning false. bIgnoreDueToRebind is not properly set back to false in the inputbox due to this.

To fix this you need to guarantee that GoTobuiltWidget function with the new swapkeysprompt is called after the UUINavComponent::NativeOnKeyUp key is triggered.

**Ok, I found a very good and neat solution. I moved the ProcessRebind call from UUINavPCComponent::HandleKeyUpEvent to the UUINavComponent::NativeOnKeyUp if.**

**The rest of the lines removed from UUINavPCComponent::HandleKeyUpEvent function were not doing anything at all...**