### PR TITLE
Linux UE 5.4.1 Compile Error Due To Operator Precedence - Update UINa…

### DIFF
--- a/Source/UINavigation/Private/UINavWidget.cpp
+++ b/Source/UINavigation/Private/UINavWidget.cpp
@@ -686,7 +686,7 @@ FReply UUINavWidget::HandleOnKeyUp(FReply Reply, UUINavWidget* Widget, UUINavCom
 		return Reply;
 	}
 
-	if (IsValid(Component) && Component->bIgnoreDueToRebind || Widget->UINavPC->IsListeningToInputRebind())
+	if ((IsValid(Component) && Component->bIgnoreDueToRebind) || Widget->UINavPC->IsListeningToInputRebind())
 	{
 		Component->bIgnoreDueToRebind = false;
 		Widget->UINavPC->ProcessRebind(InKeyEvent);


### PR DESCRIPTION
…vWidget.cpp

When compiling in UE 5.4.1 for Linux, Clang throws this error:

```
UATHelper: Packaging (Linux): F:\Unreal Projects\VeinQuest\Plugins\UINavigation\Source\UINavigation\Private\UINavWidget.cpp(689,25): error: '&&' within '||' [-Werror,-Wlogical-op-parentheses]
UATHelper: Packaging (Linux):         if (IsValid(Component) && Component->bIgnoreDueToRebind || Widget->UINavPC->IsListeningToInputRebind())
UATHelper: Packaging (Linux):             ~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ~~
UATHelper: Packaging (Linux): ...\Plugins\UINavigation\Source\UINavigation\Private\UINavWidget.cpp(689,25): note: place parentheses around the '&&' expression to silence this warning
UATHelper: Packaging (Linux):         if (IsValid(Component) && Component->bIgnoreDueToRebind || Widget->UINavPC->IsListeningToInputRebind())
UATHelper: Packaging (Linux):                                ^
UATHelper: Packaging (Linux):             (                                                  )
UATHelper: Packaging (Linux): 1 error generated.
PackagingResults: Error: '&&' within '||' [-Werror,-Wlogical-op-parentheses]
```

Seems to be due to operator precedence (even though the order is still correct as AND takes precedence...). A strange but simple bug.