### PR TITLE
Add option to lock InputDisplay to InputRestriction

### DIFF
--- a/Source/UINavigation/Private/UINavInputDisplay.cpp
+++ b/Source/UINavigation/Private/UINavInputDisplay.cpp
@@ -98,9 +98,16 @@ void UUINavInputDisplay::UpdateInputVisuals()
 	if (IsValid(InputRichText)) InputRichText->SetVisibility(ESlateVisibility::Collapsed);
 	InputImage->SetVisibility(ESlateVisibility::Collapsed);
 
+	EInputRestriction Restriction = InputMethodRestriction;
+	if(Restriction == EInputRestriction::None)
+	{
+		// if set to None, detect automatically
+		Restriction = UINavPC->IsUsingGamepad() ? EInputRestriction::Gamepad : EInputRestriction::Keyboard_Mouse;
+	}
+
 	TSoftObjectPtr<UTexture2D> NewSoftTexture = GetDefault<UUINavSettings>()->bLoadInputIconsAsync ?
-		UINavPC->GetSoftEnhancedInputIcon(InputAction, Axis, Scale, UINavPC->IsUsingGamepad() ? EInputRestriction::Gamepad : EInputRestriction::Keyboard_Mouse) :
-		UINavPC->GetEnhancedInputIcon(InputAction, Axis, Scale, UINavPC->IsUsingGamepad() ? EInputRestriction::Gamepad : EInputRestriction::Keyboard_Mouse);
+		UINavPC->GetSoftEnhancedInputIcon(InputAction, Axis, Scale, Restriction) : UINavPC->GetEnhancedInputIcon(InputAction, Axis, Scale, Restriction);
+		
 	if (!NewSoftTexture.IsNull() && DisplayType != EInputDisplayType::Text)
 	{
 		InputImage->SetBrushFromSoftTexture(NewSoftTexture, bMatchIconSize);
@@ -113,7 +120,7 @@ void UUINavInputDisplay::UpdateInputVisuals()
 	}
 	if (NewSoftTexture.IsNull() || DisplayType != EInputDisplayType::Icon)
 	{
-		const FText InputRawText = UINavPC->GetEnhancedInputText(InputAction, Axis, Scale, UINavPC->IsUsingGamepad() ? EInputRestriction::Gamepad : EInputRestriction::Keyboard_Mouse);
+		const FText InputRawText = UINavPC->GetEnhancedInputText(InputAction, Axis, Scale, Restriction);
 		if (IsValid(InputText))
 		{
 			InputText->SetText(InputRawText);

--- a/Source/UINavigation/Private/UINavInputDisplay.cpp
+++ b/Source/UINavigation/Private/UINavInputDisplay.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gonçalo Marques - All Rights Reserved
+// Copyright (C) 2023 GonÃ§alo Marques - All Rights Reserved
 
 
 #include "UINavInputDisplay.h"
@@ -28,8 +28,11 @@ void UUINavInputDisplay::NativeConstruct()
 		return;
 	}
 
-	UINavPC->UpdateInputIconsDelegate.AddDynamic(this, &UUINavInputDisplay::UpdateInputVisuals);
-
+	if (InputTypeRestriction == EInputRestriction::None)
+	{
+		UINavPC->UpdateInputIconsDelegate.AddDynamic(this, &UUINavInputDisplay::UpdateInputVisuals);
+	}
+	
 	UpdateInputVisuals();
 }
 
@@ -40,7 +43,10 @@ void UUINavInputDisplay::NativeDestruct()
 		return;
 	}
 
-	UINavPC->UpdateInputIconsDelegate.RemoveDynamic(this, &UUINavInputDisplay::UpdateInputVisuals);
+	if (InputTypeRestriction == EInputRestriction::None)
+	{
+		UINavPC->UpdateInputIconsDelegate.RemoveDynamic(this, &UUINavInputDisplay::UpdateInputVisuals);
+	}
 
 	Super::NativeDestruct();
 }
@@ -98,10 +104,9 @@ void UUINavInputDisplay::UpdateInputVisuals()
 	if (IsValid(InputRichText)) InputRichText->SetVisibility(ESlateVisibility::Collapsed);
 	InputImage->SetVisibility(ESlateVisibility::Collapsed);
 
-	EInputRestriction Restriction = InputMethodRestriction;
+	EInputRestriction Restriction = InputTypeRestriction;
 	if(Restriction == EInputRestriction::None)
 	{
-		// if set to None, detect automatically
 		Restriction = UINavPC->IsUsingGamepad() ? EInputRestriction::Gamepad : EInputRestriction::Keyboard_Mouse;
 	}
 

--- a/Source/UINavigation/Public/UINavInputDisplay.h
+++ b/Source/UINavigation/Public/UINavInputDisplay.h
@@ -15,6 +15,7 @@ class UImage;
 class UTextBlock;
 class URichTextBlock;
 class UUINavPCComponent;
+enum class EInputRestriction : uint8;
 
 /**
  * 
@@ -36,6 +37,10 @@ public:
 
 	UFUNCTION(BlueprintCallable, Category = "InputDisplay")
 	void SetInputAction(UInputAction* NewAction, const EInputAxis NewAxis, const EAxisType NewScale);
+
+	// Locks to a specific input type. If set to None, it is automatically detected
+	UPROPERTY(BlueprintReadWrite,EditAnywhere,meta=(ExposeOnSpawn),Category="InputDisplay")
+	EInputRestriction InputMethodRestriction;
 
 public:
 

--- a/Source/UINavigation/Public/UINavInputDisplay.h
+++ b/Source/UINavigation/Public/UINavInputDisplay.h
@@ -39,7 +39,7 @@ public:
 	void SetInputAction(UInputAction* NewAction, const EInputAxis NewAxis, const EAxisType NewScale);
 
 	// Locks to a specific input type. If set to None, it is automatically detected
-	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category="InputDisplay")
+	UPROPERTY(EditAnywhere, Category="InputDisplay")
 	EInputRestriction InputTypeRestriction = EInputRestriction::None;
 
 public:

--- a/Source/UINavigation/Public/UINavInputDisplay.h
+++ b/Source/UINavigation/Public/UINavInputDisplay.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Gonçalo Marques - All Rights Reserved
+// Copyright (C) 2023 GonÃ§alo Marques - All Rights Reserved
 
 #pragma once
 
@@ -7,6 +7,7 @@
 #include "Data/InputType.h"
 #include "Data/InputDisplayType.h"
 #include "Data/AxisType.h"
+#include "Data/InputRestriction.h"
 #include "Data/InputContainerEnhancedActionData.h"
 #include "Math/Vector2D.h"
 #include "UINavInputDisplay.generated.h"
@@ -39,8 +40,8 @@ public:
 	void SetInputAction(UInputAction* NewAction, const EInputAxis NewAxis, const EAxisType NewScale);
 
 	// Locks to a specific input type. If set to None, it is automatically detected
-	UPROPERTY(BlueprintReadWrite,EditAnywhere,meta=(ExposeOnSpawn),Category="InputDisplay")
-	EInputRestriction InputMethodRestriction;
+	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category="InputDisplay")
+	EInputRestriction InputTypeRestriction = EInputRestriction::None;
 
 public:
 

--- a/Source/UINavigation/Public/UINavInputDisplay.h
+++ b/Source/UINavigation/Public/UINavInputDisplay.h
@@ -16,7 +16,6 @@ class UImage;
 class UTextBlock;
 class URichTextBlock;
 class UUINavPCComponent;
-enum class EInputRestriction : uint8;
 
 /**
  * 


### PR DESCRIPTION
Adds a option to lock a UINavInputDisplay to a specific EInputRestriction. Useful if you're using InputDisplays to display icons in a options menu, but don't want them to switch out when switching between devices.
Defaults to None, which will follow old behavior (auto detecting).

Tested on version 3.8.6 and Unreal 5.3.2