### PR TITLE
Fix cursor auto-hide when the mouse is over an SSlider after dragging it

### DIFF
--- a/Source/UINavigation/Private/UINavSlider.cpp
+++ b/Source/UINavigation/Private/UINavSlider.cpp
@@ -9,6 +9,7 @@
 #include "Components/SpinBox.h"
 #include "UINavBlueprintFunctionLibrary.h"
 #include "TimerManager.h"
+#include "Widgets/Input/SSlider.h"
 
 void UUINavSlider::NativePreConstruct()
 {
@@ -141,6 +142,9 @@ void UUINavSlider::HandleOnSliderMouseCaptureEnd()
 	bMovingSlider = false;
 	OptionIndex = IndexFromPercent(Slider->GetValue());
 	Update();
+	// Workaround for a bug in SSlider: on mouse up, it "restores" the cursor to the default cursor,
+	// rather than to unset, which prevents bubbling up to UUINavGameViewportClient.
+	StaticCastSharedRef<SSlider>(Slider->TakeWidget())->SetCursor(TOptional<EMouseCursor::Type>());
 }
 
 void UUINavSlider::HandleOnSpinBoxMouseCaptureBegin()


### PR DESCRIPTION
Source of the bug:
https://github.com/EpicGames/UnrealEngine/blob/803688920e030c9a86c3659ac986030fba963833/Engine/Source/Runtime/Slate/Private/Widgets/Input/SSlider.cpp#L297
https://github.com/EpicGames/UnrealEngine/blob/803688920e030c9a86c3659ac986030fba963833/Engine/Source/Runtime/Slate/Private/Widgets/Input/SSlider.cpp#L319

Since slate bubbles up cursor queries, this value being set instead of unset overrides UINav's behavior in UUINavGameViewportClient