### PR TITLE
Make SwapKeysMessageText multiline in UINavInputContainer

### DIFF
--- a/Source/UINavigation/Public/UINavInputContainer.h
+++ b/Source/UINavigation/Public/UINavInputContainer.h
@@ -186,7 +186,7 @@ public:
 	FText SwapKeysTitleText = FText::FromString(TEXT("Swap Keys"));
 
 	//The message text used for the swap keys widget
-	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "UINav Input")
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, meta = (MultiLine = true), Category = "UINav Input")
 	FText SwapKeysMessageText = FText::FromString(TEXT("{CollidingKey} is already being used by {CollidingAction}.\nDo you want to swap it with {OtherKey}?"));
 
 };


### PR DESCRIPTION
Fixes not being able to use shift + enter to add new lines to Swap Keys Message Text in nav input containers.